### PR TITLE
fix: use placeholder image when item image is missing

### DIFF
--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -302,6 +302,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
         if not len(result_rows):
             raise Exception(f'No item with slug {slug}')
         title = result_rows[0]['title']
+        image = item_row["image"] or "/placeholder.png"
 
         return Item(
             id_=item_row["id"],
@@ -309,7 +310,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
             title=title,
             description=item_row["description"],
             body=item_row["body"],
-            image=item_row["image"],
+            image=image,
             seller=await self._profiles_repo.get_profile_by_username(
                 username=seller_username,
                 requested_user=requested_user,

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -38,6 +38,8 @@ class Item extends React.Component {
       return null;
     }
 
+    const image = this.props.item.image || "/placeholder.png";
+
     const markup = {
       __html: marked(this.props.item.description, { sanitize: true }),
     };
@@ -50,7 +52,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={image}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -28,6 +28,7 @@ const ItemPreview = (props) => {
       props.favorite(item.slug);
     }
   };
+  const image = item.image || "/placeholder.png";
 
   return (
     <div
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Use placeholder image when displaying an Item without a set image.

![image](https://user-images.githubusercontent.com/17129652/181354239-ccdbe7dc-ddfa-479a-9246-4b16b382062a.png)

